### PR TITLE
Update 'etherdream.h' for C++ compatibility

### DIFF
--- a/driver/libetherdream/etherdream.h
+++ b/driver/libetherdream/etherdream.h
@@ -2,7 +2,7 @@
 #define ETHERDREAM_H
 
 #ifdef __cplusplus
-extern "c" {
+extern "C" {
 #endif
 
 #include <stdint.h>


### PR DESCRIPTION
There was a small typo which made libetherdream not compile in C++.
