### PR TITLE
changes in .h to work with ofxEtherdream

### DIFF
--- a/driver/libetherdream/etherdream.c
+++ b/driver/libetherdream/etherdream.c
@@ -16,98 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define _POSIX_C_SOURCE 199309L
-#define _DARWIN_C_SOURCE 1
 
-#include <arpa/inet.h>
-#include <errno.h>
-#include <netinet/in.h>
-#include <netinet/tcp.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <pthread.h>
-#include <sys/ioctl.h>
-#include <sys/socket.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-
-#ifdef __MACH__
-#include <mach/mach.h>
-#include <mach/mach_time.h>
-#endif
-
-#include <protocol.h>
 #include "etherdream.h"
 
-#define BUFFER_POINTS_PER_FRAME 16000
-#define BUFFER_NFRAMES          2
-#define MAX_LATE_ACKS		64
-#define MIN_SEND_POINTS		40
-#define DEFAULT_TIMEOUT		2000000
-#define DEBUG_THRESHOLD_POINTS	800
-
-struct etherdream_conn {
-	int dc_sock;
-	char dc_read_buf[1024];
-	int dc_read_buf_size;
-	struct dac_response resp;
-	long long dc_last_ack_time;
-
-	struct {
-		struct queue_command queue;
-		struct data_command_header header;
-		struct dac_point data[1000];
-	} __attribute__((packed)) dc_local_buffer;
-
-	int dc_begin_sent;
-	int ackbuf[MAX_LATE_ACKS];
-	int ackbuf_prod;
-	int ackbuf_cons;
-	int unacked_points;
-	int pending_meta_acks;
-};
-
-struct buffer_item {
-	struct dac_point data[BUFFER_POINTS_PER_FRAME];
-	int points;
-	int pps;
-	int repeatcount;
-	int idx;
-};
-
-enum dac_state {
-	ST_DISCONNECTED,
-	ST_READY,
-	ST_RUNNING,
-	ST_BROKEN,
-	ST_SHUTDOWN
-};
-
-struct etherdream {
-	pthread_mutex_t mutex;
-	pthread_cond_t loop_cond;
-
-	struct buffer_item buffer[BUFFER_NFRAMES];
-	int frame_buffer_read;
-	int frame_buffer_fullness;
-	int bounce_count;
-
-	pthread_t workerthread;
-	
-	struct in_addr addr;
-	struct etherdream_conn conn;
-	unsigned long dac_id;
-	int sw_revision;
-	char mac_address[6];
-	char version[32];
-
-	enum dac_state state;
-
-	struct etherdream * next;
-};
 
 static FILE *trace_fp = NULL;
 #if __MACH__

--- a/driver/libetherdream/etherdream.h
+++ b/driver/libetherdream/etherdream.h
@@ -7,6 +7,39 @@ extern "C" {
 
 #include <stdint.h>
 
+
+#define _POSIX_C_SOURCE 199309L
+#define _DARWIN_C_SOURCE 1
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifdef __MACH__
+#include <mach/mach.h>
+#include <mach/mach_time.h>
+#endif
+
+#include <protocol.h>	
+
+#define BUFFER_POINTS_PER_FRAME 16000
+#define BUFFER_NFRAMES          2
+#define MAX_LATE_ACKS		64
+#define MIN_SEND_POINTS		40
+#define DEFAULT_TIMEOUT		2000000
+#define DEBUG_THRESHOLD_POINTS	800	
+
 struct etherdream_point {
 	int16_t x;
 	int16_t y;
@@ -16,6 +49,71 @@ struct etherdream_point {
 	uint16_t i;
 	uint16_t u1;
 	uint16_t u2;
+};
+
+enum dac_state {
+	ST_DISCONNECTED,
+	ST_READY,
+	ST_RUNNING,
+	ST_BROKEN,
+	ST_SHUTDOWN
+};
+
+struct etherdream_conn {
+	int dc_sock;
+	char dc_read_buf[1024];
+	int dc_read_buf_size;
+	struct dac_response resp;
+	long long dc_last_ack_time;
+
+	struct {
+		struct queue_command queue;
+		struct data_command_header header;
+		struct dac_point data[1000];
+	} __attribute__((packed)) dc_local_buffer;
+
+	int dc_begin_sent;
+	int ackbuf[MAX_LATE_ACKS];
+	int ackbuf_prod;
+	int ackbuf_cons;
+	int unacked_points;
+	int pending_meta_acks;
+};
+
+
+
+
+
+struct buffer_item {
+	struct dac_point data[BUFFER_POINTS_PER_FRAME];
+	int points;
+	int pps;
+	int repeatcount;
+	int idx;
+};
+
+
+struct etherdream {
+	pthread_mutex_t mutex;
+	pthread_cond_t loop_cond;
+
+	struct buffer_item buffer[BUFFER_NFRAMES];
+	int frame_buffer_read;
+	int frame_buffer_fullness;
+	int bounce_count;
+
+	pthread_t workerthread;
+	
+	struct in_addr addr;
+	struct etherdream_conn conn;
+	unsigned long dac_id;
+	int sw_revision;
+	char mac_address[6];
+	char version[32];
+
+	enum dac_state state;
+
+	struct etherdream * next;
 };
 
 struct etherdream;


### PR DESCRIPTION
this is a suggestion of change some structs from .c to .h file, so j4cDAC is compatible with ofxEtherdream when updated.